### PR TITLE
check for http.NoBody as well as nil Body

### DIFF
--- a/rehttp.go
+++ b/rehttp.go
@@ -282,7 +282,7 @@ type Transport struct {
 // adds retry logic as per its configuration.
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	var attempt int
-	preventRetry := req.Body != nil && t.PreventRetryWithBody
+	preventRetry := req.Body != nil && req.Body != http.NoBody && t.PreventRetryWithBody
 
 	// get the done cancellation channel for the context, will be nil
 	// for < go1.7.
@@ -290,7 +290,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	// buffer the body if needed
 	var br *bytes.Reader
-	if req.Body != nil && !preventRetry {
+	if req.Body != nil && req.Body != http.NoBody && !preventRetry {
 		var buf bytes.Buffer
 		if _, err := io.Copy(&buf, req.Body); err != nil {
 			// cannot even try the first attempt, body has been consumed


### PR DESCRIPTION
While converting some internal services to use HTTPS instead of HTTP, we were observing breakages related to having `Transfer-Encoding: chunked` and `Content-Length: -1` on `GET` requests, which makes little sense. After some long debugging sessions, we finally located the cause: The internal Go http client is upgrading the request to HTTP2, and [the code that determines the actual content length](https://github.com/golang/go/blob/go1.20/src/net/http/h2_bundle.go#L8150-L8161) requires either a `nil` body or `http.NoBody` to send a `Content-Length` of 0. Since the check for `http.NoBody` was not here, an empty byte buffer was being created, which failed the checks and caused a `Content-Length` of -1 to be used elsewhere. Adding the check here fixes the problem for us.

(We use [echo](https://github.com/labstack/echo) and it really does not like `Content-Length: -1` when binding requests to structs, event for `GET` requests.)