### PR TITLE
Promote the use of Timeout() over Temporary()

### DIFF
--- a/context_post17.go
+++ b/context_post17.go
@@ -1,3 +1,4 @@
+//go:build go1.7
 // +build go1.7
 
 package rehttp

--- a/context_pre17.go
+++ b/context_pre17.go
@@ -1,3 +1,4 @@
+//go:build !go1.7
 // +build !go1.7
 
 package rehttp

--- a/rehttp.go
+++ b/rehttp.go
@@ -188,7 +188,7 @@ func RetryTemporaryErr() RetryFn {
 // RetryTimeoutErr returns a RetryFn that retries if the Attempt's error
 // is a timeout error. Before go 1.13, a timeout error is one that implements
 // the Timeout() bool method. Most errors from the net package implement this.
-// After go 1.13, a timeout error is one that implemts the net.Error interface
+// After go 1.13, a timeout error is one that implements the net.Error interface
 // which includes both Timeout() and Temporary() to make it less likely to
 // falsely identify errors that occurred outside of the net package.
 func RetryTimeoutErr() RetryFn {

--- a/timeouterr_post113.go
+++ b/timeouterr_post113.go
@@ -1,0 +1,18 @@
+//go:build go1.13
+// +build go1.13
+
+package rehttp
+
+import (
+	"errors"
+	"net"
+)
+
+func isTimeoutErr(err error) bool {
+	var neterr net.Error
+	if errors.As(err, &neterr) && neterr.Timeout() {
+		return true
+	}
+
+	return false
+}

--- a/timeouterr_pre113.go
+++ b/timeouterr_pre113.go
@@ -1,0 +1,15 @@
+//go:build !go1.13
+// +build !go1.13
+
+package rehttp
+
+type timeouter interface {
+	Timeout() bool
+}
+
+func isTimeoutErr(err error) bool {
+	if terr, ok := err.(timeouter); ok {
+		return terr.Timeout()
+	}
+	return false
+}

--- a/timeouterr_test.go
+++ b/timeouterr_test.go
@@ -1,0 +1,42 @@
+package rehttp
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"golang.org/x/net/context"
+)
+
+func Test_isTimeoutErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "context timeouts should be retryable",
+			err:  context.DeadlineExceeded,
+			want: true,
+		},
+		{
+			name: "net op errors are true",
+			err: &net.OpError{
+				Err: timeoutErr{},
+			},
+			want: true,
+		},
+		{
+			name: "non-network related errors should not be retryable",
+			err:  errors.New("fake error"),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTimeoutErr(tt.err); got != tt.want {
+				t.Errorf("isTimeoutErr() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
See https://github.com/PuerkitoBio/rehttp/issues/6

I added an `errors.As` check for > go 1.13 to try to reduce the risk of matching just any old `Timeout()`, but it may be overkill.